### PR TITLE
Fix crash in IED minigame game over screen

### DIFF
--- a/game.py
+++ b/game.py
@@ -203,11 +203,14 @@ class IEDMiniGame:
                    (self.width//2 - game_over_text.get_width()//2, 
                     self.height//2 - 100))
         
-        # Draw final points
-        points_text = self.game_over_font.render(f"Final Score: {self.points}", True, (255, 255, 0))
-        screen.blit(points_text,
-                   (self.width//2 - points_text.get_width()//2,
-                    self.height//2))
+        # Display remaining battery as a placeholder score
+        battery_text = self.game_over_font.render(
+            f"Battery: {self.battery:.0f}%", True, (255, 255, 0)
+        )
+        screen.blit(
+            battery_text,
+            (self.width // 2 - battery_text.get_width() // 2, self.height // 2),
+        )
 
     def reset_game(self):
         """Reset the game state for another attempt"""


### PR DESCRIPTION
## Summary
- fix undefined `self.points` reference by showing battery level instead

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68423ec06a208323817ca3e7e19b677c