### PR TITLE
Fix score display in minigame

### DIFF
--- a/game.py
+++ b/game.py
@@ -32,7 +32,7 @@ class GameEvents:
         return outcomes
 
 class IEDMiniGame:
-    def __init__(self, screen_width, screen_height, initial_battery=100, lives=3, operator_mode=False):
+    def __init__(self, screen_width, screen_height, initial_battery=100, lives=3, operator_mode=False, points=0):
         self.width = screen_width
         self.height = screen_height
         self.player_pos = [(screen_width // 2) - 60, (screen_height // 2) - 60]
@@ -41,6 +41,7 @@ class IEDMiniGame:
         self.game_over = False
         self.success = False
         self.operator_mode = operator_mode
+        self.points = points
 
         # Define movement speed
         self.MOVE_SPEED = 12  # Adjust this value as needed
@@ -203,13 +204,13 @@ class IEDMiniGame:
                    (self.width//2 - game_over_text.get_width()//2, 
                     self.height//2 - 100))
         
-        # Display remaining battery as a placeholder score
-        battery_text = self.game_over_font.render(
-            f"Battery: {self.battery:.0f}%", True, (255, 255, 0)
+        # Display final score
+        score_text = self.game_over_font.render(
+            f"Final Score: {int(self.points)}", True, (255, 255, 0)
         )
         screen.blit(
-            battery_text,
-            (self.width // 2 - battery_text.get_width() // 2, self.height // 2),
+            score_text,
+            (self.width // 2 - score_text.get_width() // 2, self.height // 2),
         )
 
     def reset_game(self):

--- a/game_manager.py
+++ b/game_manager.py
@@ -105,6 +105,9 @@ class GameManager:
         if self.current_state == GameState.MINIGAME:
             current_screen.update()
             minigame = current_screen.ied_game
+
+            if minigame:
+                minigame.points = self.game_data['points']
             
             if minigame and minigame.game_over:
                 if minigame.success:
@@ -158,7 +161,8 @@ class GameManager:
         minigame_screen.init_game(
             battery=self.game_data['battery'],
             lives=self.game_data['lives'],
-            operator_mode=self.operator_mode
+            operator_mode=self.operator_mode,
+            points=self.game_data['points'],
         )
         print(f"Transitioning to minigame with {self.game_data['lives']} lives")
         self.current_state = GameState.MINIGAME

--- a/screens.py
+++ b/screens.py
@@ -150,14 +150,15 @@ class MinigameScreen(ScreenBase):
         super().__init__(*args, **kwargs)
         self.ied_game = None
         
-    def init_game(self, battery, lives, operator_mode=False):
+    def init_game(self, battery, lives, operator_mode=False, points=0):
         """Initialize the IED minigame with current lives count and operator mode"""
         self.ied_game = IEDMiniGame(
-            self.width, 
-            self.height, 
-            battery, 
+            self.width,
+            self.height,
+            battery,
             lives,
-            operator_mode
+            operator_mode,
+            points,
         )
         print(f"Minigame initialized with battery: {battery}, lives: {lives}, operator mode: {operator_mode}")
         

--- a/tests/test_game_over.py
+++ b/tests/test_game_over.py
@@ -1,0 +1,16 @@
+import os
+import pygame
+from game import IEDMiniGame
+
+
+def test_draw_game_over_screen_no_exception():
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    pygame.init()
+    screen = pygame.display.set_mode((800, 600))
+    game = IEDMiniGame(800, 600, points=42)
+    game.game_over = True
+    game.success = False
+    try:
+        game.draw_game_over_screen(screen)
+    finally:
+        pygame.quit()


### PR DESCRIPTION
## Summary
- track current score inside `IEDMiniGame`
- send score from `GameManager` when starting the minigame
- show final score on the minigame game-over screen
- ensure score is updated while playing
- add unit test for drawing the game over screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684241727d048323a68226965e0bd9c2